### PR TITLE
Enable erlang docs support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  * Support for erlang documentation (if erlang is comiled with docs)
 
 ## [0.1.1] - 2022-01-05
 ### Added

--- a/lib/exdoc_cli/help_command.ex
+++ b/lib/exdoc_cli/help_command.ex
@@ -50,6 +50,10 @@ defmodule ExdocCLI.HelpCommand do
   @impl true
   def process(%{help: true}), do: help()
 
+  def process(%{topic: <<":" <> erlang_module>>}) do
+    IEx.Helpers.h(:"#{erlang_module}")
+  end
+
   def process(%{topic: topic}) do
     {last, first_part} =
       topic

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule ExdocCLI.MixProject do
       extras: [
         "README.md": [filename: "readme", title: "Readme"],
         "CHANGELOG.md": [filename: "changelog", title: "Changelog"],
-        LICENSE: [filename: "license", title: "License"]
+        COPYING: [filename: "copying", title: "License"]
       ],
       authors: ["Matt Silbernagel"]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule ExdocCLI.MixProject do
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      docs: docs(),
       escript: escript(),
       package: package(),
       dialyzer: [
@@ -33,6 +34,19 @@ defmodule ExdocCLI.MixProject do
       {:prompt, "~> 0.7.2"},
       {:ex_doc, ">= 0.26.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.1", only: [:dev], runtime: false}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "ExdocCLI",
+      api_reference: false,
+      extras: [
+        "README.md": [filename: "readme", title: "Readme"],
+        "CHANGELOG.md": [filename: "changelog", title: "Changelog"],
+        LICENSE: [filename: "license", title: "License"]
+      ],
+      authors: ["Matt Silbernagel"]
     ]
   end
 


### PR DESCRIPTION
match if there is a starting `:` and assume erlang