### PR TITLE
Enhanced Erlang Support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+(Summarize the changes that have been made)
+
+## Checklist
+
+- [ ] fixed|updated|added unit tests and integration tests for each feature (if applicable).
+- [ ] No error nor warning in the console.
+- [ ] I added any relevent info to the [Changelog](./CHANGELOG.md).
+
+## How to test?
+
+(Describe the prerequisites and the steps to test)
+
+## Other Notes
+
+(Add any additional information that would be useful to the reviews)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+  * Pull Request Template
 
+### Fixed
+  * Allow erlang modules.function/airity i.e `:ets.new/2`
 
 ## [0.1.2] - 2022-01-09
 ### Added

--- a/test/exdoc_cli_test.exs
+++ b/test/exdoc_cli_test.exs
@@ -17,9 +17,33 @@ defmodule ExdocCLITest do
            end) =~ "0.1.3-beta"
   end
 
-  test "shows Enum.map docs" do
+  test "shows Enum.map/2 docs" do
     assert capture_io("", fn ->
              _ = ExdocCLI.main(["Enum.map/2"])
            end) =~ "Enum.map"
+  end
+
+  test "shows Enum.map docs" do
+    assert capture_io("", fn ->
+             _ = ExdocCLI.main(["Enum.map"])
+           end) =~ "Enum.map"
+  end
+
+  test "shows erlang module docs" do
+    assert capture_io("", fn ->
+             _ = ExdocCLI.main([":ets"])
+           end) =~ ":ets"
+  end
+
+  test "shows erlang module function docs" do
+    assert capture_io("", fn ->
+             _ = ExdocCLI.main([":ets.new"])
+           end) =~ "new(name, options)"
+  end
+
+  test "shows erlang module function airity docs" do
+    assert capture_io("", fn ->
+             _ = ExdocCLI.main([":ets.new/2"])
+           end) =~ "new(name, options)"
   end
 end


### PR DESCRIPTION
## Summary

Allows for users to pass in erlang modules such as `:ets` or `:ets.new/2`

## Checklist

- [x] fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No error nor warning in the console.
- [x] I added any relevent info to the [Changelog](./CHANGELOG.md).

## How to test?

* Build the escript (`mix escript.build`)
* run `./exdoc :ets` (or any other standard erlang module)

## Other Notes

(Add any additional information that would be useful to the reviews)